### PR TITLE
Update LSF::Batch's Batch.xs so it will compile on LSF < 9.1.3

### DIFF
--- a/LSF-Batch/Batch.xs
+++ b/LSF-Batch/Batch.xs
@@ -6976,7 +6976,9 @@ rie_creator(self)
     OUTPUT:
         RETVAL
 
-#if LSF_VERSION >= LSF_XDR_VERSION9_1_3
+#if LSF_PRODUCT_MAJOR_VERSION    >= 9 && \
+    LSF_PRODUCT_MINOR_VERSION    >= 1 && \
+    LSF_PRODUCT_MAINTAIN_VERSION >= 3
 
 char *
 rie_rsvUnit(self)


### PR DESCRIPTION
- LSF::Batch's Batch.xs should compile for LSF versions < 9.1.3 now, since those systems (most likely) do not have LSF_XDR_VERSION9_1_3 defined in <lsf/lsf.h>
- see PlatformLSF/perlAPI#2