### PR TITLE
lsf-L3-tracker#924 defined(@array) was deprecated in perl 5.36

### DIFF
--- a/LSF-Batch/test.pl
+++ b/LSF-Batch/test.pl
@@ -47,7 +47,7 @@ print "ok 2\n";
 $ok3 = 1;
 
 @user = ( );   
-defined(@user) or warn "no user names are given.           \t";
+warn "no user names are given.           \t" unless (@user);
 
 @userinfo = $b->userinfo(\@user) or $ok3 = 0;
 foreach $user (@userinfo){
@@ -81,7 +81,7 @@ unless( @resinfo ){
 }
 
 @hostparts = ( );
-defined(@hostparts) or warn "no hostparts given.               \t" ;
+warn "no hostparts are given.               \t" unless (@hostparts);
 @partinfo = $b->hostpartinfo(\@hostparts);
 $ok3 = 0 unless @partinfo;
 
@@ -440,7 +440,7 @@ $err6 = 1 unless length($mypeek) != 0;
 @hosts = ();
 $slots = 1;
 $options = RUNJOB_OPT_NORMAL;  # RUNJOB_OPT_NORMAL = 1;
-defined(@hosts) or warn "no host names are given.          \t" ;
+warn "no host names are given.          \t" unless (@hosts);
 $myrun = $myjob->run(\@hosts, $slots, $options);
 $err7 = 1 unless $myrun;
 


### PR DESCRIPTION
[root@stmhost07 LSF-Batch]# make test
"/root/perl5/perlbrew/perls/perl-5.36.0/bin/perl" -MExtUtils::Command::MM -e 'cp_nonempty' -- Batch.bs blib/arch/auto/LSF/Batch/Batch.bs 644
PERL_DL_NONLAZY=1 "/root/perl5/perlbrew/perls/perl-5.36.0/bin/perl" "-Iblib/lib" "-Iblib/arch" test.pl
1..25
Can't use 'defined(@array)' (Maybe you should just omit the defined()?) at test.pl line 50.
not ok 1
make: *** [test_dynamic] Error 2

5. the error is due to that the defined(@array) was deprecated in recent version of perl like 5.36. Updating test.pl at line 50 as below can fix the error.

==>> before:
defined(@user) or warn "no user names are given.           \t";

==>> after:
if(@user) {
   print "user names are ok";
 }
 else {
   print "no user names are given.           \t";
 }

The same is for line 90 and line 456.
