### PR TITLE
add $submit->userPriority

### DIFF
--- a/LSF-Batch/Batch.pm
+++ b/LSF-Batch/Batch.pm
@@ -1375,6 +1375,7 @@ Corporation's Load Sharing Facility (LSF).
   $submit->queue;
   $submit->resReq;
   $submit->command;
+  $submit->userPriority;
   #etc.
 
   $batch->closejobinfo();

--- a/LSF-Batch/Batch.xs
+++ b/LSF-Batch/Batch.xs
@@ -11031,6 +11031,14 @@ sub_chkpntPeriod(self)
     OUTPUT:
 	RETVAL
 
+int
+sub_userPriority(self)
+	LSF_Batch_submit *self
+    CODE:
+	RETVAL = self->userPriority;
+    OUTPUT:
+	RETVAL
+
 char *
 sub_chkpntDir(self)
 	LSF_Batch_submit *self


### PR DESCRIPTION

```
cat $LSF_SERVERDIR/esub
#!/usr/bin/perl
use LSF::Batch;
my $batch = new LSF::Batch("esub");
my $newjob = new LSF::Batch::jobPtr($jobid, $index);
my $records = $batch->openjobinfo($newjob, "", "", "", "", &ALL_JOB);
my $jobinfo = $batch->readjobinfo();
my $submit = $jobinfo->submit();
#my $priority = $submit->userPriority;
my $priority = $newjob->userPriority;

[chzhao@bjhc01 LSF-Batch]$ bsub sleep 100
Can't locate object method "userPriority" via package "LSF::Batch::jobPtr" at /scratch/lsfbj03/chzhao/Test_LSF/LSF10_spk9/10.1/linux3.10-glibc2.17-x86_64/etc/esub line 9.
```

After fix:

```
[root@cgdev1 etc]# cat esub
#!/usr/bin/perl
use LSF::Batch;
my $batch = new LSF::Batch("esub");
my $newjob = new LSF::Batch::jobPtr($jobid, $index);
my $records = $batch->openjobinfo($newjob, "", "", "", "", &ALL_JOB);
my $jobinfo = $batch->readjobinfo();
my $submit = $jobinfo->submit();
my $command = $submit->command;
my $priority = $submit->userPriority;
#my $priority = $newjob->userPriority;

[root@cgdev1 etc]# bsub bsub sleep 100
Job <449> is submitted to default queue <normal>.
```