### PR TITLE
Fixed set_postexec() in Batch.xs

### DIFF
--- a/LSF-Batch/Batch.xs
+++ b/LSF-Batch/Batch.xs
@@ -4851,7 +4851,7 @@ int set_postexec( struct submit *s, char *key, SV* value ){
     return -1;
   }
   s->postExecCmd = (char *)SvPV(value, len);
-  s->options3 |= SUB_PRE_EXEC;
+  s->options3 |= SUB3_POST_EXEC;
   return 0;
 }
 


### PR DESCRIPTION
Encountered LSF crashes when using the -Ep parameter

```
$ ./test_submit.pl
format: got flag -Ep
format: got flag -J
format: got flag -o
format: got flag -E
format: got flag -m
format: got flag -command
Cannot connect to LSF. Please wait ...
```

After fix
```
$ ./test_submit.pl
format: got flag -Ep
format: got flag -J
format: got flag -o
format: got flag -E
format: got flag -m
format: got flag -command
Job <232889> is submitted to default queue <normal>.
Id=232889
```
